### PR TITLE
Added handoff code. Needs to be merged with limelight-competition later on. 

### DIFF
--- a/src/main/java/frc/robot/Constants/Constants.java
+++ b/src/main/java/frc/robot/Constants/Constants.java
@@ -35,13 +35,15 @@ public final class Constants {
 	}
 
 	public static class ShooterConstants {
-	
+		public static final int pivotMotorID = 50;
 	}
 
 	public static class IntakeConstants {
 		public static final int intakeMotor1ID = 41;
 		public static final int intakeMotor2ID = 42;
 		public static final int intakeMotor3ID = 43;
+		public static final int ampMotor1ID = 44;
+		public static final int ampMotor2ID = 45;
 	}
 
 	public static class LEDConstants {

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -1,6 +1,6 @@
 package frc.robot.subsystems;
 
-import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkFlex;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 
 import edu.wpi.first.wpilibj2.command.Command;
@@ -11,10 +11,12 @@ import frc.robot.Constants.Constants.IntakeConstants;
 
 public class IntakeSubsystem extends SubsystemBase {
     
-    private CANSparkMax[] intakeMotors = new CANSparkMax[]{
-        new CANSparkMax(IntakeConstants.intakeMotor1ID, MotorType.kBrushless),
-        new CANSparkMax(IntakeConstants.intakeMotor2ID, MotorType.kBrushless),
-        new CANSparkMax(IntakeConstants.intakeMotor3ID, MotorType.kBrushless),
+    private CANSparkFlex[] intakeMotors = new CANSparkFlex[]{
+        new CANSparkFlex(IntakeConstants.intakeMotor1ID, MotorType.kBrushless),
+        new CANSparkFlex(IntakeConstants.intakeMotor2ID, MotorType.kBrushless),
+        new CANSparkFlex(IntakeConstants.intakeMotor3ID, MotorType.kBrushless),
+        new CANSparkFlex(IntakeConstants.ampMotor1ID, MotorType.kBrushless),
+        new CANSparkFlex(IntakeConstants.ampMotor2ID, MotorType.kBrushless)
     };
 
     public boolean isReadytoIntake() {
@@ -48,7 +50,7 @@ public class IntakeSubsystem extends SubsystemBase {
     }
 
     private void stopIntakeMotors(){
-        for (CANSparkMax motor:intakeMotors){
+        for (CANSparkFlex motor:intakeMotors){
             motor.set(0);
         }
     }

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -10,13 +10,15 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.Constants.IntakeConstants;
 
 public class IntakeSubsystem extends SubsystemBase {
-    
+    public IntakeSubsystem(){
+        intakeMotors[4].setInverted(true);
+    }
     private CANSparkFlex[] intakeMotors = new CANSparkFlex[]{
-        new CANSparkFlex(IntakeConstants.intakeMotor1ID, MotorType.kBrushless),
-        new CANSparkFlex(IntakeConstants.intakeMotor2ID, MotorType.kBrushless),
-        new CANSparkFlex(IntakeConstants.intakeMotor3ID, MotorType.kBrushless),
-        new CANSparkFlex(IntakeConstants.ampMotor1ID, MotorType.kBrushless),
-        new CANSparkFlex(IntakeConstants.ampMotor2ID, MotorType.kBrushless)
+            new CANSparkFlex(IntakeConstants.intakeMotor1ID, MotorType.kBrushless),
+            new CANSparkFlex(IntakeConstants.intakeMotor2ID, MotorType.kBrushless),
+            new CANSparkFlex(IntakeConstants.intakeMotor3ID, MotorType.kBrushless),
+            new CANSparkFlex(IntakeConstants.ampMotor1ID, MotorType.kBrushless),
+            new CANSparkFlex(IntakeConstants.ampMotor2ID, MotorType.kBrushless)
     };
 
     public boolean isReadytoIntake() {


### PR DESCRIPTION
The reason this code is reliant on the limelight code (that needs to be adapted for YAGSL) is because it assumes everything in intaking position (when the encoders read the position as 0). Other than that, the code should successfully complete the hand-off (PENDING TESTING)